### PR TITLE
Add dev CLI for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 This project installs a small command line tool called `zero-ai-dev-framework`.
 After `pip install -e .` you can run `zero-ai-dev-framework --help`.
+An alias `zcc` is also provided for convenience and supports a `dev` command.

--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -1,23 +1,16 @@
 # Table of Contents
 
 ## Main Notes
-- [00 Project Action Anchor](00projectanchor-template.md)
+- [00 Project Action Anchor](00projectanchor-consult-clouds-bdf74c3e.md)
 - [How to Add Wiki Articles](main_notes_adding_wiki_articles.md)
 - [As a Human: How to Code with Codex](main_notes_as_a_human_how_to_code_with_codex.md)
 - [Best Practices for Coding with Codex](main_notes_best_practices_coding_with_codex.md)
-- [Research Output: Business Value from LiftSim](main_notes_business_value_research.md)
 - [Checkpoint - Primary Classes Implemented - pink-walk](main_notes_checkpoint_prim_classes.md)
 - [Project Rules/Conventions for Codex](main_notes_codex_must_read_this_rules_for_codex.md)
-- [05 Devplan - Current](main_notes_devplan.md)
 - [Docstring Style Guide](main_notes_docstring_style_guide.md)
 - [codex: Update the Table of Contents](main_notes_for_codex_update_toc.md)
 - [Styleguide for Wiki Articles](main_notes_styleguide_wiki_articles.md)
 - [Wiki Article Creation Instructions for Codex](main_notes_wiki_article_creation_for_codex.md)
 
-## Prompt Articles
-- [prompt2 - bugfix apathetic-fall 6ad38cd4](prompt2-apathetic-fall-6ad38cd4.md)
-- [prompt1 - generate instance for new project](prompt1-normal-associate-763211a8.md)
-- [prompt0 Implement CLI frequent-heart 9190f354](prompt0_frequent_heart_9190f354.md)
-
 ## Articles
-- [unnamed worthless-vacation 782e571a](unnamed-worthless-vacation-782e571a.md)
+- [Project Purpose and Scope](prompt0.md)

--- a/docs/main_notes_as_a_human_how_to_code_with_codex.md
+++ b/docs/main_notes_as_a_human_how_to_code_with_codex.md
@@ -32,7 +32,7 @@ The key idea is to treat Codex as a collaborator that works best with tightly sc
    - Summarize design decisions or tricky behavior in the wiki.  
    - Keep the docs short but explicit so future prompts can reference them.
 6. **Update the Table of Contents**  
-   - Execute `zero-ai-dev-framework dev --update-toc` to regenerate `docs/CONTENTS.md` whenever docs are added or renamed.
+   - Execute `zcc dev --update-doc` to regenerate `docs/CONTENTS.md` whenever docs are added or renamed.
 7. **Commit Cleanly**  
    - Review diffs, remove stray edits, and ensure docstrings follow the style guide.  
    - Commit related code and docs together with a concise message.

--- a/docs/main_notes_for_codex_update_toc.md
+++ b/docs/main_notes_for_codex_update_toc.md
@@ -3,6 +3,6 @@
 #process-notes
 ***
 
-for codex: execute zero-ai-dev-framework dev --update-toc to regenerate docs/CONTENTS.md whenever docs are added or renamed.
+for codex: execute zcc dev --update-doc to regenerate docs/CONTENTS.md whenever docs are added or renamed.
 
 

--- a/docs/main_notes_wiki_article_creation_for_codex.md
+++ b/docs/main_notes_wiki_article_creation_for_codex.md
@@ -18,5 +18,5 @@ random codename: <codename that you'll generate>
 ```
 
 
-also, whenever you update or create any `md` file in "docs/", the last thing before commit you should do is run `zero-ai-dev-framework dev --update-toc` or the code equivalent (i.e. use the code to update CONTENTS.md you don't edit).
+also, whenever you update or create any `md` file in "docs/", the last thing before commit you should do is run `zcc dev --update-doc` or the code equivalent (i.e. use the code to update CONTENTS.md you don't edit).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.scripts]
 zero-gptcli-clouds = "zero_consult_clouds.cli:main"
+zcc = "zero_consult_clouds.cli:main"
 
 [tool.setuptools.packages.find]
 include = ["zero_consult_clouds"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,5 +34,24 @@ def test_convo(monkeypatch, tmp_path):
     assert out.read_text(encoding="utf-8") == "hi"
 
 
+def test_dev_update_doc(tmp_path):
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.md").write_text("# Title", encoding="utf-8")
+
+    import importlib
+    from zero_consult_clouds import cli as cli_mod
+    importlib.reload(cli_mod)
+    code = cli_mod.main([
+        "dev",
+        "--update-doc",
+        "--docs-dir",
+        str(docs_dir),
+    ])
+    assert code == 0
+    contents = docs_dir / "CONTENTS.md"
+    assert contents.exists()
+
+
 
 

--- a/zero_consult_clouds/cli.py
+++ b/zero_consult_clouds/cli.py
@@ -4,6 +4,7 @@ from typing import List
 
 from .chat import ChatGPT
 from .config import CONFIG_FILE, setup_config
+from .docs_tools import update_toc
 
 
 def _cmd_setup_config(args: argparse.Namespace) -> int:
@@ -37,6 +38,16 @@ def _cmd_convo(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_dev(args: argparse.Namespace) -> int:
+    if args.update_doc:
+        try:
+            update_toc(docs_dir=args.docs_dir)
+        except Exception as exc:  # pragma: no cover - unexpected
+            print(f"error: {exc}")
+            return 1
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog='zero-gptcli-clouds')
     sub = parser.add_subparsers(dest='command', required=True)
@@ -53,6 +64,11 @@ def build_parser() -> argparse.ArgumentParser:
     convo.add_argument('-o', '--output', type=Path, required=True)
     convo.add_argument('--config', type=Path, default=CONFIG_FILE)
     convo.set_defaults(func=_cmd_convo)
+
+    dev = sub.add_parser('dev')
+    dev.add_argument('--update-doc', action='store_true')
+    dev.add_argument('--docs-dir', type=Path)
+    dev.set_defaults(func=_cmd_dev)
 
     return parser
 


### PR DESCRIPTION
## Summary
- add zcc alias and a new `dev` command with `--update-doc` option
- document the new CLI alias and command
- update documentation references to use the new command
- regenerate table of contents for docs
- test updating docs via CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d5dfc1208323879f08c965463524