### PR TITLE
Add new-doc option to CLI dev command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,5 +53,23 @@ def test_dev_update_doc(tmp_path):
     assert contents.exists()
 
 
+def test_dev_new_doc(tmp_path):
+    docs_dir = tmp_path / "docs"
+
+    import importlib
+    from zero_consult_clouds import cli as cli_mod
+    importlib.reload(cli_mod)
+    code = cli_mod.main([
+        "dev",
+        "--new-doc",
+        "--docs-dir",
+        str(docs_dir),
+    ])
+    assert code == 0
+    files = list(docs_dir.glob("*.md"))
+    assert len(files) == 1
+    assert files[0].read_text(encoding="utf-8").startswith("# unnamed")
+
+
 
 

--- a/zero_consult_clouds/cli.py
+++ b/zero_consult_clouds/cli.py
@@ -4,7 +4,7 @@ from typing import List
 
 from .chat import ChatGPT
 from .config import CONFIG_FILE, setup_config
-from .docs_tools import update_toc
+from .docs_tools import new_doc, update_toc
 
 
 def _cmd_setup_config(args: argparse.Namespace) -> int:
@@ -39,6 +39,12 @@ def _cmd_convo(args: argparse.Namespace) -> int:
 
 
 def _cmd_dev(args: argparse.Namespace) -> int:
+    if args.new_doc:
+        try:
+            new_doc(docs_dir=args.docs_dir)
+        except Exception as exc:  # pragma: no cover - unexpected
+            print(f"error: {exc}")
+            return 1
     if args.update_doc:
         try:
             update_toc(docs_dir=args.docs_dir)
@@ -67,6 +73,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     dev = sub.add_parser('dev')
     dev.add_argument('--update-doc', action='store_true')
+    dev.add_argument('--new-doc', action='store_true')
     dev.add_argument('--docs-dir', type=Path)
     dev.set_defaults(func=_cmd_dev)
 


### PR DESCRIPTION
## Summary
- allow `zero-consult-clouds dev` to create a new document
- test new `--new-doc` CLI flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d96c9a7483239c822c34a7b9960b