### PR TITLE
Implement rewrite loops CLI

### DIFF
--- a/docs/CONTENTS.md
+++ b/docs/CONTENTS.md
@@ -18,5 +18,6 @@
 
 ## Articles
 - [big-period d86cc2dd](big-period-d86cc2dd.md)
+- [prompt2 simple re-write loops therapeutic-essay 3e4c6fa9](prompt2_therapeutic-essay-3e4c6fa9.md)
+- [tutorial therapeutic-essay 3e4c6fa9](tutorial_therapeutic-essay-3e4c6fa9.md)
 - [unnamed slow-beginning f3a7ec9f](unnamed-slow-beginning-f3a7ec9f.md)
-- [unnamed therapeutic-essay 3e4c6fa9](prompt2_therapeutic-essay-3e4c6fa9.md)

--- a/docs/tutorial_therapeutic-essay-3e4c6fa9.md
+++ b/docs/tutorial_therapeutic-essay-3e4c6fa9.md
@@ -1,0 +1,13 @@
+# tutorial therapeutic-essay 3e4c6fa9
+
+This tutorial explains how to use the **rewrite loops** feature added in response to prompt2.
+
+1. Prepare a markdown file containing your initial draft followed by `***` and a second section describing its purpose and fitness goals.
+2. Run:
+   ```bash
+   zero-consult-clouds loops -f path/to/input.md
+   ```
+   Use `--safe` to skip API calls or `--dummy` for quick dummy output useful in tests.
+3. The tool first prints a bullet summary of the purpose. Confirm to continue and provide optional comments for each iteration.
+4. After each rewrite the improved text is saved as `convo-YYYYMMDD-vN.md` in the same directory. Bullet points describing the changes are printed.
+5. You may stop after any iteration. A final score report comparing all versions is displayed at the end.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,5 +74,30 @@ def test_dev_new_doc(tmp_path):
     assert files[0].read_text(encoding="utf-8").startswith("# unnamed")
 
 
+def test_loops_dummy(tmp_path):
+    cfg_path = tmp_path / "c.yaml"
+    save_config(
+        Config(api_key="k", default_output_dir=str(tmp_path)),
+        cfg_path,
+    )
+    inp = tmp_path / "doc.md"
+    inp.write_text("draft\n***\ncontext", encoding="utf-8")
+
+    import importlib
+    from zero_consult_clouds import cli as cli_mod
+    importlib.reload(cli_mod)
+    code = cli_mod.main([
+        "loops",
+        "-f",
+        str(inp),
+        "--config",
+        str(cfg_path),
+        "--dummy",
+    ])
+    assert code == 0
+    files = list(tmp_path.glob("convo-*.md"))
+    assert files
+
+
 
 

--- a/zero_consult_clouds/__init__.py
+++ b/zero_consult_clouds/__init__.py
@@ -21,3 +21,6 @@ __all__ = [
     "setup_config",
     "cli",
 ]
+from .rewrite_loops import iterative_rewrite
+
+__all__.append("iterative_rewrite")

--- a/zero_consult_clouds/cli.py
+++ b/zero_consult_clouds/cli.py
@@ -5,6 +5,7 @@ from typing import List
 
 from .chat import ChatGPT, write_history
 from .config import CONFIG_FILE, load_config, setup_config
+from .rewrite_loops import iterative_rewrite
 from .docs_tools import update_toc, new_doc
 
 
@@ -82,6 +83,20 @@ def _cmd_dev(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_loops(args: argparse.Namespace) -> int:
+    try:
+        iterative_rewrite(
+            args.file,
+            config_path=args.config,
+            safe=args.safe,
+            dummy=args.dummy,
+        )
+    except Exception as exc:  # pragma: no cover - unexpected
+        print(f"error: {exc}")
+        return 1
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog='zero-gptcli-clouds')
     sub = parser.add_subparsers(dest='command', required=True)
@@ -100,6 +115,13 @@ def build_parser() -> argparse.ArgumentParser:
     convo.add_argument('--disable-history-write', action='store_true')
     convo.add_argument('--promptlib-pretext', action='append')
     convo.set_defaults(func=_cmd_convo)
+
+    loops = sub.add_parser('loops')
+    loops.add_argument('-f', '--file', type=Path, required=True)
+    loops.add_argument('--config', type=Path, default=CONFIG_FILE)
+    loops.add_argument('--safe', action='store_true')
+    loops.add_argument('--dummy', action='store_true')
+    loops.set_defaults(func=_cmd_loops)
 
     dev = sub.add_parser('dev')
     dev.add_argument('--update-toc', action='store_true')

--- a/zero_consult_clouds/rewrite_loops.py
+++ b/zero_consult_clouds/rewrite_loops.py
@@ -1,0 +1,104 @@
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, List
+
+from .chat import ChatGPT
+from .config import CONFIG_FILE
+
+
+_DEFAULT_MAX_ITER = 5
+
+
+def _parse_sections(text: str) -> tuple[str, str]:
+    parts = re.split(r"\n\*\*\*\n", text, maxsplit=1)
+    if len(parts) == 2:
+        return parts[0].strip(), parts[1].strip()
+    # fallback: split roughly in half
+    lines = text.splitlines()
+    mid = len(lines) // 2
+    return "\n".join(lines[:mid]).strip(), "\n".join(lines[mid:]).strip()
+
+
+def _dummy_send(prompt: str) -> str:
+    return "dummy response"
+
+
+def _safe_send(prompt: str) -> str:
+    return "safe mode: no api call"
+
+
+def iterative_rewrite(
+    input_file: Path,
+    *,
+    config_path: Path = CONFIG_FILE,
+    max_iter: int = _DEFAULT_MAX_ITER,
+    safe: bool = False,
+    dummy: bool = False,
+) -> List[Path]:
+    text = input_file.read_text(encoding="utf-8")
+    draft, context = _parse_sections(text)
+
+    if dummy:
+        send: Callable[[str], str] = _dummy_send
+    elif safe:
+        send = _safe_send
+    else:
+        chat = ChatGPT(config_path=config_path)
+        send = chat.send
+    interactive = not (safe or dummy)
+
+    summary = send(
+        "Summarize the purpose and fitness goals in 5 bullet points:\n" + context
+    )
+    print(summary)
+    if interactive:
+        cont = input("Continue? [y/N] ").strip().lower()
+        if cont != "y":
+            return []
+
+    versions: List[str] = [draft]
+    output_paths: List[Path] = []
+    out_dir = input_file.parent
+    for i in range(1, max_iter + 1):
+        if interactive:
+            comments = input("Comments (or 'q' to quit): ").strip()
+            if comments.lower() == "q":
+                break
+        else:
+            comments = ""
+        prompt = (
+            "Rewrite the following draft to better meet the purpose. "
+            "After the rewrite, provide 5 bullet points describing the changes.\n"
+            f"Context:\n{context}\nComments:\n{comments}\nDraft:\n{versions[-1]}"
+        )
+        result = send(prompt)
+        lines = result.strip().splitlines()
+        bullet_idx = next((j for j, l in enumerate(lines) if l.startswith("-")), len(lines))
+        new_text = "\n".join(lines[:bullet_idx]).strip()
+        bullets = "\n".join(lines[bullet_idx:]).strip()
+        fname = f"convo-{datetime.utcnow():%Y%m%d}-v{i}.md"
+        out_path = out_dir / fname
+        out_path.write_text(new_text, encoding="utf-8")
+        output_paths.append(out_path)
+        print(bullets)
+        versions.append(new_text)
+        if interactive:
+            again = input("Another iteration? [y/N] ").strip().lower()
+            if again != "y":
+                break
+        else:
+            break
+
+    final_prompt = (
+        "Score each version on fitness criteria and explain briefly.\n" +
+        context + "\n" + "\n".join(
+            f"Version {idx}:\n{v}" for idx, v in enumerate(versions)
+        )
+    )
+    final = send(final_prompt)
+    print(final)
+    return output_paths
+
+
+__all__ = ["iterative_rewrite"]


### PR DESCRIPTION
## Summary
- add new module `rewrite_loops` implementing iterative rewriting loops
- expose `iterative_rewrite` in library API
- add `loops` subcommand to CLI
- document usage in **tutorial therapeutic-essay 3e4c6fa9**
- update docs table of contents
- test the new CLI command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536482ca28832385d93b3021c5122f