### PR TITLE
Improve terminal response viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pandas",
     "matplotlib",
     "openai",
+    "rich",
     "PyYAML",
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,7 @@ def test_dev_new_doc(tmp_path):
     assert files[0].read_text(encoding="utf-8").startswith("# unnamed")
 
 
-def test_loops_dummy(tmp_path):
+def test_loops_dummy(tmp_path, monkeypatch):
     cfg_path = tmp_path / "c.yaml"
     save_config(
         Config(api_key="k", default_output_dir=str(tmp_path)),
@@ -82,6 +82,8 @@ def test_loops_dummy(tmp_path):
     )
     inp = tmp_path / "doc.md"
     inp.write_text("draft\n***\ncontext", encoding="utf-8")
+
+    monkeypatch.setenv("PAGER", "cat")
 
     import importlib
     from zero_consult_clouds import cli as cli_mod

--- a/zero_consult_clouds/cli.py
+++ b/zero_consult_clouds/cli.py
@@ -121,7 +121,8 @@ def _cmd_loops(options: argparse.Namespace) -> int:
     """Handle the ``loops`` sub-command."""
 
     print(options.file)
-    input('here? >')
+    if not (options.dummy or options.safe):
+        input('here? >')
     if str(options.file) == 'i':
         k = 'fp_ path to input prompt (use zcc util -t) > '
         x = interactive_fill({k:0})

--- a/zero_consult_clouds/interactive_viewer.py
+++ b/zero_consult_clouds/interactive_viewer.py
@@ -1,0 +1,38 @@
+"""Simple interactive viewer for API responses."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from rich.console import Console
+from rich.markdown import Markdown
+
+# Reuse color codes from interactive_fill for visual consistency
+RESET = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[96m"
+
+
+def interactive_view(text: str) -> None:
+    """Display ``text`` in a pager with light Markdown rendering.
+
+    The output uses ``less`` for navigation with basic Vim-style commands.
+    Lines wrap at 120 columns.
+    """
+
+    console = Console(width=120, record=True)
+    console.print(Markdown(text))
+    body = console.export_text()
+
+    header = f"""{BOLD}{CYAN}
+===============================================================================
+Move with j/k. g/G for start/end. / to search. n for next result. q to quit.
+Press 'q' to continue to the next step.
+===============================================================================
+{RESET}"""
+
+    content = header + "\n" + body
+
+    pager = os.environ.get("PAGER", "less -R")
+    subprocess.run(pager, input=content.encode("utf-8"), shell=True)
+

--- a/zero_consult_clouds/rewrite_loops.py
+++ b/zero_consult_clouds/rewrite_loops.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Callable, List
 
 from .chat import ChatGPT
+from .interactive_viewer import interactive_view
 from .config import CONFIG_FILE
 
 
@@ -51,7 +52,7 @@ def iterative_rewrite(
     summary = send(
         "Summarize the purpose and fitness goals in 5 bullet points:\n" + context
     )
-    print(summary)
+    interactive_view(summary)
     if interactive:
         cont = input("Continue? [y/N] ").strip().lower()
         if cont != "y":
@@ -81,7 +82,7 @@ def iterative_rewrite(
         out_path = out_dir / fname
         out_path.write_text(new_text, encoding="utf-8")
         output_paths.append(out_path)
-        print(bullets)
+        interactive_view(bullets)
         versions.append(new_text)
         if interactive:
             again = input("Another iteration? [y/N] ").strip().lower()
@@ -97,7 +98,7 @@ def iterative_rewrite(
         )
     )
     final = send(final_prompt)
-    print(final)
+    interactive_view(final)
     return output_paths
 
 


### PR DESCRIPTION
## Summary
- add `interactive_view` pager to show API responses with a light markdown view and VIM navigation hints
- display API results in `iterative_rewrite` using `interactive_view`
- skip an interactive prompt when `loops` command runs in safe or dummy mode
- ensure tests run non-interactively with `PAGER=cat`
- include `rich` in project dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685380677cb08323aef813e3f0428b36