### PR TITLE
Improve display formatting

### DIFF
--- a/zero_consult_clouds/interactive_viewer.py
+++ b/zero_consult_clouds/interactive_viewer.py
@@ -2,37 +2,10 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
-from rich.console import Console
-from rich.markdown import Markdown
-
-# Reuse color codes from interactive_fill for visual consistency
-RESET = "\033[0m"
-BOLD = "\033[1m"
-CYAN = "\033[96m"
+from .zerox_terminal_display import terminal_display
 
 
 def interactive_view(text: str) -> None:
-    """Display ``text`` in a pager with light Markdown rendering.
+    """Display ``text`` in a pager with consistent Markdown rendering."""
 
-    The output uses ``less`` for navigation with basic Vim-style commands.
-    Lines wrap at 120 columns.
-    """
-
-    console = Console(width=80, record=True)
-    console.print(Markdown(text))
-    body = console.export_text()
-
-    header = f"""{BOLD}{CYAN}
-===============================================================================
-Move with j/k. g/G for start/end. / to search. n for next result. q to quit.
-Press 'q' to continue to the next step.
-===============================================================================
-{RESET}"""
-
-    content = header + "\n" + body
-
-    pager = os.environ.get("PAGER", "less -R")
-    subprocess.run(pager, input=content.encode("utf-8"), shell=True)
-
+    terminal_display(text, scroll=True, chatbot=True)

--- a/zero_consult_clouds/zerox_terminal_display.py
+++ b/zero_consult_clouds/zerox_terminal_display.py
@@ -13,26 +13,40 @@ GREEN = "\033[92m"
 YELLOW = "\033[93m"
 BLINK = "\033[5m"
 
+CHAT_BG_STYLE = "on grey11"
 
-def zerox_terminal_display(text: str) -> None:
-    """Render ``text`` in a pager with light markdown support.
 
-    The output is wrapped at 100 characters wide and shows navigation instructions.
+def terminal_display(text: str, *, scroll: bool = True, chatbot: bool = False) -> None:
+    """Render ``text`` with light markdown support.
+
+    Parameters
+    ----------
+    text:
+        Content to display.
+    scroll:
+        If True, show in a pager with navigation instructions.
+    chatbot:
+        If True, apply a subtle background color to highlight chatbot output.
     """
-
-    console = Console(width=100, record=True)
-    console.print(Markdown(text))
+    console = Console(width=80, record=scroll)
+    style = CHAT_BG_STYLE if chatbot else ""
+    console.print(Markdown(text), style=style)
     body = console.export_text()
 
-    header = f"""{BOLD}{CYAN}
+    if scroll:
+        header = f"""{BOLD}{CYAN}
 ==============================================================================
 Move with j/k. g/G for start/end. / to search. n for next result. q to quit.
 {GREEN}{BLINK}Press 'q' to continue.{RESET}{CYAN}
 ==============================================================================
 {RESET}"""
+        content = header + "\n" + body
+        pager = os.environ.get("PAGER", "less -R")
+        subprocess.run(pager, input=content.encode("utf-8"), shell=True)
+    else:
+        print(body)
 
-    content = header + "\n" + body
-    pager = os.environ.get("PAGER", "less -R")
-    subprocess.run(pager, input=content.encode("utf-8"), shell=True)
+# Backwards compatibility
+zerox_terminal_display = terminal_display
 
-__all__ = ["zerox_terminal_display"]
+__all__ = ["terminal_display", "zerox_terminal_display"]


### PR DESCRIPTION
## Summary
- consolidate interactive view with terminal display helper
- add background highlight for chatbot content
- unify markdown formatting across scrolling and non-scrolling output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685399bc6be483239efb3dcb6e00b7c5