### PR TITLE
Implement promptlib manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ run `pip install -e . ` and then you should have `zero-consult-clouds --help`.
 
 To ask chatgpt a question and get a response, use `zero-consult-clouds convo -f /l/tmp/input.md -o /l/tmp/output.md`.
 
+The CLI now includes a basic `promptlib` manager for browsing and viewing prompt
+files:
+
+- `zero-consult-clouds promptlib browse` opens an interactive picker.
+- `zero-consult-clouds promptlib cat <uuid>` prints a prompt by UUID.
+- `zero-consult-clouds promptlib stats` shows library statistics.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "matplotlib",
     "openai",
     "rich",
+    "prompt_toolkit",
     "PyYAML",
     "tiktoken",
 ]

--- a/tests/test_promptlib_cli.py
+++ b/tests/test_promptlib_cli.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from zero_consult_clouds.config import Config, save_config
+
+
+def _setup(tmp_path: Path) -> Path:
+    cfg_path = tmp_path / "c.yaml"
+    save_config(
+        Config(api_key="k", model="m", model_tokenmax=16000, promptlib_dir=str(tmp_path / "pl")),
+        cfg_path,
+    )
+    pl_dir = tmp_path / "pl"
+    pl_dir.mkdir()
+    (pl_dir / "1234promptlib-test.md").write_text("line1\nline2", encoding="utf-8")
+    return cfg_path
+
+
+def test_promptlib_cat(tmp_path, capsys):
+    cfg = _setup(tmp_path)
+
+    import importlib
+    from zero_consult_clouds import cli as cli_mod
+    importlib.reload(cli_mod)
+
+    code = cli_mod.main([
+        "promptlib",
+        "cat",
+        "1234",
+        "--config",
+        str(cfg),
+    ])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "line1" in captured.out
+
+
+def test_promptlib_stats(tmp_path, capsys):
+    cfg = _setup(tmp_path)
+
+    import importlib
+    from zero_consult_clouds import cli as cli_mod
+    importlib.reload(cli_mod)
+
+    code = cli_mod.main([
+        "promptlib",
+        "stats",
+        "--config",
+        str(cfg),
+    ])
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "1 promptlib files" in captured.out

--- a/zero_consult_clouds/__init__.py
+++ b/zero_consult_clouds/__init__.py
@@ -8,7 +8,7 @@ from .config import (
     save_config,
     setup_config,
 )
-from . import cli
+from . import cli, promptlib
 
 __version__ = "0.1.0"
 
@@ -20,6 +20,7 @@ __all__ = [
     "save_config",
     "setup_config",
     "cli",
+    "promptlib",
 ]
 from .rewrite_loops import iterative_rewrite
 from .chunking_processor import chunk_content, build_context_windows

--- a/zero_consult_clouds/promptlib.py
+++ b/zero_consult_clouds/promptlib.py
@@ -1,0 +1,87 @@
+"""Utility functions for managing promptlib archives."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+__all__ = [
+    "iter_prompt_files",
+    "first_line",
+    "browse",
+    "cat",
+    "stats",
+]
+
+
+def iter_prompt_files(path: Path, filter_text: str | None = None):
+    """Yield promptlib files in ``path`` matching ``filter_text``."""
+    for fp in sorted(path.glob("*promptlib*")):
+        if filter_text and filter_text not in fp.name:
+            continue
+        if fp.is_file():
+            yield fp
+
+
+def first_line(path: Path) -> str:
+    """Return the first non-empty line of ``path`` or an empty string."""
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                return line
+    except Exception:
+        pass
+    return ""
+
+
+def browse(path: Path, filter_text: str = "") -> str | None:
+    """Interactive prompt selector.
+
+    Parameters
+    ----------
+    path:
+        Directory containing promptlib files.
+    filter_text:
+        Optional substring filter for filenames.
+
+    Returns
+    -------
+    str | None
+        Selected file path or ``None`` if aborted.
+    """
+    files = list(iter_prompt_files(path, filter_text))
+    if not files:
+        print("no prompts found")
+        return None
+
+    values = []
+    for fp in files:
+        line = first_line(fp)
+        label = f"{fp.name}\n    * {line}"
+        values.append((str(fp), label))
+
+    from prompt_toolkit.shortcuts import radiolist_dialog
+
+    app = radiolist_dialog(
+        title="promptlib browse",
+        text=f"promptlib archive: {path}\ntotal: {len(files)} prompts",
+        values=values,
+        ok_text="select",
+        cancel_text="quit",
+    )
+    return app.run()
+
+
+def cat(path: Path, uuid: str) -> str:
+    """Return prompt content matching ``uuid``."""
+    matches = [p for p in path.glob(f"*{uuid}*promptlib*") if p.is_file()]
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one match for {uuid}, found {len(matches)}")
+    return matches[0].read_text(encoding="utf-8")
+
+
+def stats(path: Path) -> tuple[int, Path]:
+    """Return number of prompt files and archive path."""
+    total = len(list(iter_prompt_files(path)))
+    return total, path


### PR DESCRIPTION
## Summary
- add promptlib management module
- expose promptlib in public API
- extend CLI with `promptlib` subcommands
- document usage in README
- add dependency on prompt_toolkit
- test cat and stats commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bfaac04483239044a4a48fce6799