### PR TITLE
Add append feature to promptlib browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ To ask chatgpt a question and get a response, use `zero-consult-clouds convo -f 
 The CLI now includes a basic `promptlib` manager for browsing and viewing prompt
 files:
 
-- `zero-consult-clouds promptlib browse` opens an interactive picker.
+- `zero-consult-clouds promptlib browse` opens an interactive picker and
+  appends the chosen prompt to `/l/obs-chaotic/prompt.md` (use `--output` to
+  change the file).
 - `zero-consult-clouds promptlib cat <uuid>` prints a prompt by UUID.
 - `zero-consult-clouds promptlib stats` shows library statistics.
 

--- a/tests/test_promptlib_cli.py
+++ b/tests/test_promptlib_cli.py
@@ -1,11 +1,17 @@
 from pathlib import Path
+
 from zero_consult_clouds.config import Config, save_config
 
 
 def _setup(tmp_path: Path) -> Path:
     cfg_path = tmp_path / "c.yaml"
     save_config(
-        Config(api_key="k", model="m", model_tokenmax=16000, promptlib_dir=str(tmp_path / "pl")),
+        Config(
+            api_key="k",
+            model="m",
+            model_tokenmax=16000,
+            promptlib_dir=str(tmp_path / "pl"),
+        ),
         cfg_path,
     )
     pl_dir = tmp_path / "pl"
@@ -18,16 +24,20 @@ def test_promptlib_cat(tmp_path, capsys):
     cfg = _setup(tmp_path)
 
     import importlib
+
     from zero_consult_clouds import cli as cli_mod
+
     importlib.reload(cli_mod)
 
-    code = cli_mod.main([
-        "promptlib",
-        "cat",
-        "1234",
-        "--config",
-        str(cfg),
-    ])
+    code = cli_mod.main(
+        [
+            "promptlib",
+            "cat",
+            "1234",
+            "--config",
+            str(cfg),
+        ]
+    )
     captured = capsys.readouterr()
     assert code == 0
     assert "line1" in captured.out
@@ -37,15 +47,79 @@ def test_promptlib_stats(tmp_path, capsys):
     cfg = _setup(tmp_path)
 
     import importlib
+
     from zero_consult_clouds import cli as cli_mod
+
     importlib.reload(cli_mod)
 
-    code = cli_mod.main([
-        "promptlib",
-        "stats",
-        "--config",
-        str(cfg),
-    ])
+    code = cli_mod.main(
+        [
+            "promptlib",
+            "stats",
+            "--config",
+            str(cfg),
+        ]
+    )
     captured = capsys.readouterr()
     assert code == 0
     assert "1 promptlib files" in captured.out
+
+
+def test_promptlib_browse_passes_output(tmp_path, monkeypatch):
+    cfg = _setup(tmp_path)
+    out = tmp_path / "out.md"
+
+    called = {}
+
+    def fake_browse(path, filter_text="", output_file=None):
+        called["path"] = path
+        called["output_file"] = output_file
+        return None
+
+    monkeypatch.setattr("zero_consult_clouds.promptlib.browse", fake_browse)
+
+    import importlib
+
+    from zero_consult_clouds import cli as cli_mod
+
+    importlib.reload(cli_mod)
+
+    code = cli_mod.main(
+        [
+            "promptlib",
+            "browse",
+            "--config",
+            str(cfg),
+            "--output",
+            str(out),
+        ]
+    )
+
+    assert code == 0
+    assert called["output_file"] == out
+
+
+def test_browse_appends(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "pl"
+    pl_dir.mkdir()
+    p = pl_dir / "1234promptlib-test.md"
+    p.write_text("line1", encoding="utf-8")
+
+    out = tmp_path / "out.md"
+
+    # fake radiolist so no interactive UI
+    class FakeApp:
+        def run(self):
+            return str(p)
+
+    monkeypatch.setattr(
+        "prompt_toolkit.shortcuts.radiolist_dialog",
+        lambda **kwargs: FakeApp(),
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+
+    from zero_consult_clouds import promptlib as pl
+
+    pl.browse(pl_dir, output_file=out)
+
+    assert out.read_text(encoding="utf-8").strip() == "line1"

--- a/zero_consult_clouds/cli.py
+++ b/zero_consult_clouds/cli.py
@@ -2,33 +2,33 @@ import argparse
 from pathlib import Path
 from typing import Callable, List
 from uuid import uuid4 as uuid
+
 from codenamize import codenamize
 
-
-from .chat import ChatGPT, write_history
-from .helpers import extract_template_vars, load_asset_template, codename
-from .interactive_fill import interactive_fill
-from .config import CONFIG_FILE, load_config, setup_config
-from .rewrite_loops import iterative_rewrite
-from .docs_tools import update_toc, new_doc
 from . import promptlib as promptlib_mod
+from .chat import ChatGPT, write_history
+from .config import CONFIG_FILE, load_config, setup_config
+from .docs_tools import new_doc, update_toc
+from .helpers import codename, extract_template_vars, load_asset_template
+from .interactive_fill import interactive_fill
+from .rewrite_loops import iterative_rewrite
 
 
 def _cmd_util(options: argparse.Namespace) -> int:
     """Handle the ``util`` sub-command."""
 
     if options.fill_template:
-        print('this is hard coded to filling out writing_product for now')
+        print("this is hard coded to filling out writing_product for now")
         t = load_asset_template(str(options.fill_template))
         d = extract_template_vars(t)
-        fp = interactive_fill({'fp_writing_product':0})['fp_writing_product']
-        with open(fp, 'r') as f:
+        fp = interactive_fill({"fp_writing_product": 0})["fp_writing_product"]
+        with open(fp, "r") as f:
             writing_product = f.read()
-        d['uuid'] = str(uuid())
-        d['codename'] = codenamize(d['uuid'])
-        d['writing_product'] = writing_product
+        d["uuid"] = str(uuid())
+        d["codename"] = codenamize(d["uuid"])
+        d["writing_product"] = writing_product
         fp = options.output_filepath
-        with open(fp, 'w') as f:
+        with open(fp, "w") as f:
             f.write(t.render(d))
         print(f"wrote '{fp}")
 
@@ -122,10 +122,10 @@ def _cmd_loops(options: argparse.Namespace) -> int:
 
     print(options.file)
     if not (options.dummy or options.safe):
-        input('ready, prob going to send api calls ? >')
-    if str(options.file) == 'i':
-        k = 'fp_ path to input prompt (use zcc util -t) > '
-        x = interactive_fill({k:0})
+        input("ready, prob going to send api calls ? >")
+    if str(options.file) == "i":
+        k = "fp_ path to input prompt (use zcc util -t) > "
+        x = interactive_fill({k: 0})
         options.file = x[k]
     try:
         iterative_rewrite(
@@ -146,7 +146,11 @@ def _cmd_promptlib_browse(options: argparse.Namespace) -> int:
         cfg = load_config(options.config)
         if cfg.promptlib_dir is None:
             raise RuntimeError("promptlib_dir not configured")
-        selected = promptlib_mod.browse(Path(cfg.promptlib_dir), options.filter)
+        selected = promptlib_mod.browse(
+            Path(cfg.promptlib_dir),
+            options.filter,
+            options.output,
+        )
         if selected:
             print(selected)
     except Exception as exc:  # pragma: no cover - unexpected
@@ -190,10 +194,10 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     util_parser = subparsers.add_parser("util")
-    util_parser.add_argument("--output-filepath", "-f", type=Path,
-                             default="/l/tmp/prompt.md")
-    util_parser.add_argument("--fill-template", "-t", type=Path,
-                             default="")
+    util_parser.add_argument(
+        "--output-filepath", "-f", type=Path, default="/l/tmp/prompt.md"
+    )
+    util_parser.add_argument("--fill-template", "-t", type=Path, default="")
     util_parser.set_defaults(func=_cmd_util)
 
     cfg_parser = subparsers.add_parser("setup-config")
@@ -223,6 +227,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     browse_parser = pl_sub.add_parser("browse")
     browse_parser.add_argument("--filter", default="")
+    browse_parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("/l/obs-chaotic/prompt.md"),
+        help="File to append the selected prompt to",
+    )
     browse_parser.add_argument("--config", type=Path, default=CONFIG_FILE)
     browse_parser.set_defaults(func=_cmd_promptlib_browse)
 
@@ -258,4 +268,4 @@ def main(argv: List[str] | None = None) -> int:
     return handler(parsed_args)
 
 
-__all__ = ['main', 'build_parser']
+__all__ = ["main", "build_parser"]


### PR DESCRIPTION
## Summary
- extend `promptlib.browse` to optionally append the chosen prompt to a markdown file
- support `--output` argument in CLI so users can pick the destination
- document the new behaviour in README
- test that CLI passes output path and that browse writes to file

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c98264148323b503723fb1032d66