### PR TITLE
Simplify promptlib browse

### DIFF
--- a/tests/test_promptlib_cli.py
+++ b/tests/test_promptlib_cli.py
@@ -107,16 +107,12 @@ def test_browse_appends(tmp_path, monkeypatch):
 
     out = tmp_path / "out.md"
 
-    # fake radiolist so no interactive UI
-    class FakeApp:
-        def run(self):
-            return str(p)
+    inputs = ["1", "y"]
 
-    monkeypatch.setattr(
-        "prompt_toolkit.shortcuts.radiolist_dialog",
-        lambda **kwargs: FakeApp(),
-    )
-    monkeypatch.setattr("builtins.input", lambda *a, **k: "y")
+    def fake_input(*args, **kwargs):
+        return inputs.pop(0)
+
+    monkeypatch.setattr("builtins.input", fake_input)
 
     from zero_consult_clouds import promptlib as pl
 

--- a/zero_consult_clouds/promptlib.py
+++ b/zero_consult_clouds/promptlib.py
@@ -59,25 +59,27 @@ def browse(
         print("no prompts found")
         return None
 
-    values = []
-    for fp in files:
+    print(f"promptlib archive: {path}")
+    print(f"total: {len(files)} prompts")
+
+    items = []
+    for i, fp in enumerate(files, 1):
         line = first_line(fp)
-        label = f"{fp.name}\n    * {line}"
-        values.append((str(fp), label))
+        print(f"[{i}] {fp.name} - {line}")
+        items.append(fp)
 
-    from prompt_toolkit.shortcuts import radiolist_dialog
-
-    app = radiolist_dialog(
-        title="promptlib browse",
-        text=f"promptlib archive: {path}\ntotal: {len(files)} prompts",
-        values=values,
-        ok_text="select",
-        cancel_text="quit",
-    )
-    selected = app.run()
-
-    if not selected:
-        return None
+    while True:
+        sel = input("Select number or 'q' to quit: ").strip().lower()
+        if sel in {"q", "quit", ""}:
+            return None
+        try:
+            idx = int(sel) - 1
+            if 0 <= idx < len(items):
+                selected = items[idx]
+                break
+        except ValueError:
+            pass
+        print("invalid selection")
 
     if output_file is None:
         output_file = Path("/l/obs-chaotic/prompt.md")


### PR DESCRIPTION
## Summary
- replace promptlib GUI dialog with simple stdin loop
- adjust tests for new input-driven workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d00999f0832394d3bbdf8d6f6f05