### PR TITLE
Add fuzzy search for promptlib browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ To ask chatgpt a question and get a response, use `zero-consult-clouds convo -f 
 The CLI now includes a basic `promptlib` manager for browsing and viewing prompt
 files:
 
-- `zero-consult-clouds promptlib browse` opens an interactive picker and
-  appends the chosen prompt to `/l/obs-chaotic/prompt.md` (use `--output` to
-  change the file).
+- `zero-consult-clouds promptlib browse` opens an interactive picker with fuzzy
+  search and appends the chosen prompt to `/l/obs-chaotic/prompt.md` (use
+  `--output` to change the file).
 - `zero-consult-clouds promptlib cat <uuid>` prints a prompt by UUID.
 - `zero-consult-clouds promptlib stats` shows library statistics.
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,7 +1,10 @@
 from zero_consult_clouds.config import Config, save_config
+import os
 
 
 def test_send(monkeypatch, tmp_path):
+    os.makedirs("/l/obs-chaotic", exist_ok=True)
+    os.makedirs("/l/gds", exist_ok=True)
     cfg_path = tmp_path / "c.yaml"
     save_config(Config(api_key="k", model="m", model_tokenmax=16000), cfg_path)
 

--- a/tests/test_promptlib_cli.py
+++ b/tests/test_promptlib_cli.py
@@ -109,10 +109,11 @@ def test_browse_appends(tmp_path, monkeypatch):
 
     inputs = ["1", "y"]
 
-    def fake_input(*args, **kwargs):
+    def fake_prompt(*args, **kwargs):
         return inputs.pop(0)
 
-    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr("prompt_toolkit.PromptSession.prompt", fake_prompt)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: inputs.pop(0))
 
     from zero_consult_clouds import promptlib as pl
 

--- a/zero_consult_clouds/promptlib.py
+++ b/zero_consult_clouds/promptlib.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import FuzzyWordCompleter
+
 __all__ = [
     "iter_prompt_files",
     "first_line",
@@ -62,23 +65,40 @@ def browse(
     print(f"promptlib archive: {path}")
     print(f"total: {len(files)} prompts")
 
-    items = []
+    mapping: dict[str, Path] = {}
+    display_items = []
     for i, fp in enumerate(files, 1):
         line = first_line(fp)
-        print(f"[{i}] {fp.name} - {line}")
-        items.append(fp)
+        display = f"{fp.name} - {line}"
+        print(f"[{i}] {display}")
+        mapping[str(i)] = fp
+        mapping[display] = fp
+        display_items.append(display)
+
+    session = PromptSession()
+    completer = FuzzyWordCompleter(display_items)
 
     while True:
-        sel = input("Select number or 'q' to quit: ").strip().lower()
-        if sel in {"q", "quit", ""}:
-            return None
         try:
-            idx = int(sel) - 1
-            if 0 <= idx < len(items):
-                selected = items[idx]
-                break
-        except ValueError:
-            pass
+            sel = session.prompt(
+                "Select number or search text ('q' to quit): ",
+                completer=completer,
+                complete_in_thread=True,
+            ).strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
+
+        if sel.lower() in {"q", "quit", ""}:
+            return None
+
+        if sel.isdigit() and sel in mapping:
+            selected = mapping[sel]
+            break
+
+        if sel in mapping:
+            selected = mapping[sel]
+            break
+
         print("invalid selection")
 
     if output_file is None:


### PR DESCRIPTION
## Summary
- enable fuzzy search in `promptlib.browse`
- document fuzzy search support in README
- update tests for new interactive function
- ensure chat tests create required directories

## Testing
- `pytest -q`
- `ruff check .`
- `black --check .` *(fails: would reformat)*

------
https://chatgpt.com/codex/tasks/task_e_68570542bc1c8323ae7119686bbca3a4