### PR TITLE
Add fuzzy word matching to prompt browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ To ask chatgpt a question and get a response, use `zero-consult-clouds convo -f 
 The CLI now includes a basic `promptlib` manager for browsing and viewing prompt
 files:
 
-- `zero-consult-clouds promptlib browse` opens an interactive picker and
-  appends the chosen prompt to `/l/obs-chaotic/prompt.md` (use `--output` to
-  change the file).
+- `zero-consult-clouds promptlib browse` opens an interactive picker with fuzzy
+  search that supports arrow-key navigation and typing partial names to select
+  prompts, then appends the chosen prompt to
+  `/l/obs-chaotic/prompt.md` (use `--output` to change the file).
 - `zero-consult-clouds promptlib cat <uuid>` prints a prompt by UUID.
 - `zero-consult-clouds promptlib stats` shows library statistics.
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,7 +1,10 @@
 from zero_consult_clouds.config import Config, save_config
+import os
 
 
 def test_send(monkeypatch, tmp_path):
+    os.makedirs("/l/obs-chaotic", exist_ok=True)
+    os.makedirs("/l/gds", exist_ok=True)
     cfg_path = tmp_path / "c.yaml"
     save_config(Config(api_key="k", model="m", model_tokenmax=16000), cfg_path)
 

--- a/tests/test_promptlib_cli.py
+++ b/tests/test_promptlib_cli.py
@@ -109,13 +109,39 @@ def test_browse_appends(tmp_path, monkeypatch):
 
     inputs = ["1", "y"]
 
-    def fake_input(*args, **kwargs):
+    def fake_prompt(*args, **kwargs):
         return inputs.pop(0)
 
-    monkeypatch.setattr("builtins.input", fake_input)
+    monkeypatch.setattr("prompt_toolkit.PromptSession.prompt", fake_prompt)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: inputs.pop(0))
 
     from zero_consult_clouds import promptlib as pl
 
     pl.browse(pl_dir, output_file=out)
 
     assert out.read_text(encoding="utf-8").strip() == "line1"
+
+
+def test_browse_fuzzy_match(tmp_path, monkeypatch):
+    pl_dir = tmp_path / "pl"
+    pl_dir.mkdir()
+    p1 = pl_dir / "111promptlib-vibeunknown.md"
+    p1.write_text("aaa", encoding="utf-8")
+    (pl_dir / "222promptlib-other.md").write_text("bbb", encoding="utf-8")
+
+    out = tmp_path / "out.md"
+
+    inputs = ["vibe unknown", "y"]
+
+    def fake_prompt(*args, **kwargs):
+        return inputs.pop(0)
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession.prompt", fake_prompt)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: inputs.pop(0))
+
+    from zero_consult_clouds import promptlib as pl
+
+    selected = pl.browse(pl_dir, output_file=out)
+
+    assert selected == p1
+    assert out.read_text(encoding="utf-8").strip() == "aaa"


### PR DESCRIPTION
## Summary
- enhance `promptlib browse` fuzzy search so typing words selects prompts
- mention partial-name selection support in README
- test fuzzy token matching

## Testing
- `pytest -q`
- `ruff check .` *(fails: F401, F821, E401, etc.)*
- `black --check .` *(fails: would reformat 17 files)*

------
https://chatgpt.com/codex/tasks/task_e_68570542bc1c8323ae7119686bbca3a4